### PR TITLE
Create account request endpoint

### DIFF
--- a/lib/controller/account.ex
+++ b/lib/controller/account.ex
@@ -1,0 +1,26 @@
+defmodule Controller.Account do
+  @moduledoc """
+  Account controller manages details of account modifications
+  POST - request create of Account details
+  PATCH - request modification of account details
+  DELETE - request removal of Account details
+  TODO: GET - get read optimized account details
+  """
+  alias Response.Json, as: Json
+  alias Model.Account.Request, as: Request
+  use Plug.Router
+  plug :match
+  plug :dispatch
+
+  post "/" do
+    account_request = Json.parse(conn, type: Request)
+    Request.validate(account_request)
+    Json.render(
+      conn,
+      body: %{accepted: account_request})
+  end
+
+  match _ do
+    Json.render(conn, status: 404)
+  end
+end

--- a/lib/model/account/request.ex
+++ b/lib/model/account/request.ex
@@ -1,0 +1,13 @@
+defmodule Model.Account.Request do
+  @moduledoc """
+  Account request object
+  """
+  @derive [Poison.Encoder]
+  defstruct [:first_name, :last_name, :email]
+
+  def validate(request) do
+    unless request.first_name, do: throw [message: "First Name Missing", http_code: 400]
+    unless request.last_name, do: throw [message: "Last Name Missing", http_code: 400]
+    unless request.email, do: throw [message: "Email Missing", http_code: 400]
+  end
+end

--- a/lib/model/account/request.ex
+++ b/lib/model/account/request.ex
@@ -3,11 +3,29 @@ defmodule Model.Account.Request do
   Account request object
   """
   @derive [Poison.Encoder]
-  defstruct [:first_name, :last_name, :email]
+  @required_keys [:first_name, :last_name, :email]
+  defstruct @required_keys
 
   def validate(request) do
-    unless request.first_name, do: throw [message: "First Name Missing", http_code: 400]
-    unless request.last_name, do: throw [message: "Last Name Missing", http_code: 400]
-    unless request.email, do: throw [message: "Email Missing", http_code: 400]
+    validate_array = validate_keysp(@required_keys, request)
+    error_keys = Enum.filter(
+      validate_array,
+      fn tuple -> elem(tuple, 1) == false end)
+    if length(error_keys) > 0,
+      do: throw [message: generate_error_messages(error_keys), http_code: 400]
+  end
+
+  defp generate_error_messages(errors) do
+    Enum.map(errors, fn err -> "#{elem(err, 0)} is missing." end)
+  end
+
+  defp validate_keysp(required, request) do
+    Enum.map(
+      required,
+      fn(k) -> key_presentp(k, Map.get(request, k)) end)
+  end
+
+  defp key_presentp(key, value) do
+    {key, value != nil}
   end
 end

--- a/lib/response/json.ex
+++ b/lib/response/json.ex
@@ -14,10 +14,17 @@ defmodule Response.Json do
   def parse(conn, type: type), do: prse(conn, options: %{as: type})
   def parse(conn),             do: prse(conn, options: %{})
 
-  def fail(conn, status, message: message) do
+  def fail(conn, message: message, http_code: http_code), do: failp(conn, http_code, message)
+  def fail(conn, http_code: status),                do: failp(conn, status, "#{status}")
+  def fail(conn, message: body),                    do: failp(conn, 500, body)
+  def fail(conn),                                   do: failp(conn, 500, "Server Error")
+
+  #Private
+
+  defp failp(conn, status, body) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(status, Poison.encode!(%{error: message}))
+    |> send_resp(status, Poison.encode!(%{error: body}))
   end
 
   defp renderp(conn, body, status) do

--- a/lib/response/json.ex
+++ b/lib/response/json.ex
@@ -6,10 +6,10 @@ defmodule Response.Json do
   """
   import Plug.Conn
 
-  def render(conn), do: rend(conn, %{}, 200)
-  def render(conn, body: body), do: rend(conn, body, 200)
-  def render(conn, status: status), do: rend(conn, %{}, status)
-  def render(conn, body: body, status: status), do: rend(conn, body, status)
+  def render(conn), do: renderp(conn, %{}, 200)
+  def render(conn, body: body), do: renderp(conn, body, 200)
+  def render(conn, status: status), do: renderp(conn, %{}, status)
+  def render(conn, body: body, status: status), do: renderp(conn, body, status)
 
   def parse(conn, type: type), do: prse(conn, options: %{as: type})
   def parse(conn),             do: prse(conn, options: %{})
@@ -20,9 +20,7 @@ defmodule Response.Json do
     |> send_resp(status, Poison.encode!(%{error: message}))
   end
 
-  #Private
-
-  defp rend(conn, body, status) do
+  defp renderp(conn, body, status) do
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(status, Poison.encode!(body))

--- a/lib/response/json.ex
+++ b/lib/response/json.ex
@@ -11,12 +11,21 @@ defmodule Response.Json do
   def render(conn, status: status), do: rend(conn, %{}, status)
   def render(conn, body: body, status: status), do: rend(conn, body, status)
 
+  def parse(conn, type: type), do: prse(conn, options: %{as: type})
+  def parse(conn),             do: prse(conn, options: %{})
+
   #Private
 
   defp rend(conn, body, status) do
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(status, Poison.encode!(body))
+  end
+
+  alias Plug.Conn, as: Connection
+  defp prse(conn, options: options) do
+    {:ok, body, _} = Connection.read_body(conn, length: 1_000_000)
+    Poison.decode!(body, options)
   end
 
 end

--- a/lib/response/json.ex
+++ b/lib/response/json.ex
@@ -14,6 +14,12 @@ defmodule Response.Json do
   def parse(conn, type: type), do: prse(conn, options: %{as: type})
   def parse(conn),             do: prse(conn, options: %{})
 
+  def fail(conn, status, message: message) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Poison.encode!(%{error: message}))
+  end
+
   #Private
 
   defp rend(conn, body, status) do

--- a/lib/router/base.ex
+++ b/lib/router/base.ex
@@ -12,6 +12,7 @@ defmodule Router.Base do
   plug :dispatch
 
   forward "/about", to: Controller.About
+  forward "/account", to: Controller.Account
   forward "/",      to: Controller.Root
 
   def handle_errors(conn, %{kind: kind, reason: reason, stack: _stack}) do

--- a/lib/router/base.ex
+++ b/lib/router/base.ex
@@ -15,12 +15,7 @@ defmodule Router.Base do
   forward "/account", to: Controller.Account
   forward "/",      to: Controller.Root
 
-  def handle_errors(conn, %{kind: kind, reason: reason, stack: _stack}) do
-    status = set_status_from_kind(kind)
-    Json.fail(conn, status, message: reason)
-  end
-
-  defp set_status_from_kind(kind) do
-    if kind == :throw, do: 400, else: 500
+  def handle_errors(conn, %{kind: _kind, reason: reason, stack: _stack}) do
+    Json.fail(conn, reason)
   end
 end

--- a/lib/router/base.ex
+++ b/lib/router/base.ex
@@ -4,10 +4,22 @@ defmodule Router.Base do
   each controller's defined path
   """
   use Plug.Router
+  use Plug.ErrorHandler
+
+  alias Response.Json, as: Json
 
   plug :match
   plug :dispatch
 
   forward "/about", to: Controller.About
   forward "/",      to: Controller.Root
+
+  def handle_errors(conn, %{kind: kind, reason: reason, stack: _stack}) do
+    status = set_status_from_kind(kind)
+    Json.fail(conn, status, message: reason)
+  end
+
+  defp set_status_from_kind(kind) do
+    if kind == :throw, do: 400, else: 500
+  end
 end

--- a/test/controller/about_test.exs
+++ b/test/controller/about_test.exs
@@ -1,0 +1,23 @@
+defmodule Controller.AboutTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  @opts Router.Base.init([])
+  test "GET /about/:foo returns foo" do
+    conn = conn(:get, "/about/foo")
+    conn = Router.Base.call(conn, @opts)
+
+    assert conn.state == :sent
+    assert conn.status == 200
+    assert String.match?(conn.resp_body, ~r/foo/)
+  end
+
+  test "GET /about/:foo/bar returns 404" do
+    conn = conn(:get, "/about/foo/bar")
+    conn = Router.Base.call(conn, @opts)
+
+    assert conn.state == :sent
+    assert conn.status == 404
+  end
+
+end

--- a/test/controller/root_test.exs
+++ b/test/controller/root_test.exs
@@ -1,4 +1,4 @@
-defmodule JsonSvcTest do
+defmodule Controller.RootTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
@@ -21,23 +21,6 @@ defmodule JsonSvcTest do
     assert String.match?(conn.resp_body, ~r/ok/)
   end
 
-  test "GET /about/:foo returns foo" do
-    conn = conn(:get, "/about/foo")
-    conn = Router.Base.call(conn, @opts)
-
-    assert conn.state == :sent
-    assert conn.status == 200
-    assert String.match?(conn.resp_body, ~r/foo/)
-  end
-
-  test "GET /about/:foo/bar returns 404" do
-    conn = conn(:get, "/about/foo/bar")
-    conn = Router.Base.call(conn, @opts)
-
-    assert conn.state == :sent
-    assert conn.status == 404
-  end
-
   test "GET /randomunknownroute returns 404" do
     conn = conn(:get, "/randomunknownroute")
     conn = Router.Base.call(conn, @opts)
@@ -45,4 +28,5 @@ defmodule JsonSvcTest do
     assert conn.state == :sent
     assert conn.status == 404
   end
+
 end


### PR DESCRIPTION
details in individual commits:
 1. re-organizes tests to be more specific to their usage
 1. adds json failure handler
 1. adds proto model for validating incoming account requests and throwing an error if attributes are incorrect
 1. exposes `post` endpoint for account requests