### PR TITLE
[DOC] GitHub pages docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # The directory Mix downloads your dependencies sources to.
 /deps
 
+/docs/.build
+
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,10 +12,11 @@ defmodule JsonSvc.Mixfile do
      # Docs
      name: "JsonSvcEx",
      source_url: "https://github.com/chiengineer/json_svc_ex",
-     homepage_url: "https://github.com/chiengineer/json_svc_ex/wiki",
+     homepage_url: "https://chiengineer.github.io/json_svc_ex/",
      docs: [
        main: "JsonSvcEx", # The main page in the docs
-       extras: ["README.md"]
+       extras: ["README.md"],
+       output: "docs" #folder required for github pages docs
      ]
    ]
   end


### PR DESCRIPTION
moves files to supported github-pages `docs` folder