### PR TITLE
[CLEANUP] use correct typing for request

### DIFF
--- a/docs/Controller.About.html
+++ b/docs/Controller.About.html
@@ -109,7 +109,7 @@ all endpoints are aliased with <code class="inline">/about/*</code> based on <a 
     <a href="#call/2">call(conn, opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
 </div>
   
 </div>
@@ -118,7 +118,7 @@ all endpoints are aliased with <code class="inline">/about/*</code> based on <a 
     <a href="#init/1">init(opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
 </div>
   
 </div>
@@ -159,7 +159,7 @@ all endpoints are aliased with <code class="inline">/about/*</code> based on <a 
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
 
   </section>
 </div>
@@ -179,7 +179,7 @@ all endpoints are aliased with <code class="inline">/about/*</code> based on <a 
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
 
   </section>
 </div>

--- a/docs/Controller.Account.html
+++ b/docs/Controller.Account.html
@@ -118,7 +118,7 @@ TODO: GET - get read optimized account details</p>
     <a href="#call/2">call(conn, opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
 </div>
   
 </div>
@@ -127,7 +127,7 @@ TODO: GET - get read optimized account details</p>
     <a href="#init/1">init(opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
 </div>
   
 </div>
@@ -168,7 +168,7 @@ TODO: GET - get read optimized account details</p>
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
 
   </section>
 </div>
@@ -188,7 +188,7 @@ TODO: GET - get read optimized account details</p>
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
 
   </section>
 </div>

--- a/docs/Controller.Root.html
+++ b/docs/Controller.Root.html
@@ -111,7 +111,7 @@ external watchdog resource</p>
     <a href="#call/2">call(conn, opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
 </div>
   
 </div>
@@ -120,7 +120,7 @@ external watchdog resource</p>
     <a href="#init/1">init(opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
 </div>
   
 </div>
@@ -161,7 +161,7 @@ external watchdog resource</p>
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
 
   </section>
 </div>
@@ -181,7 +181,7 @@ external watchdog resource</p>
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
 
   </section>
 </div>

--- a/docs/Response.Json.html
+++ b/docs/Response.Json.html
@@ -99,7 +99,7 @@ supports skipping one or both extra params</p>
     <a href="#fail/1">fail(conn)</a>
   </div>
   
-    <div class="summary-synopsis"><p>This function sends a failure message to a <a href="https://hexdocs.pm/plug/0.14.0/Plug.Conn.html"><code class="inline">Plug.Conn</code></a> connected client</p>
+    <div class="summary-synopsis"><p>This function sends a failure message to a <a href="https://hexdocs.pm/plug/1.3.4/Plug.Conn.html"><code class="inline">Plug.Conn</code></a> connected client</p>
 </div>
   
 </div>
@@ -182,14 +182,14 @@ supports skipping one or both extra params</p>
     
   </div>
   <section class="docstring">
-    <p>This function sends a failure message to a <a href="https://hexdocs.pm/plug/0.14.0/Plug.Conn.html"><code class="inline">Plug.Conn</code></a> connected client</p>
+    <p>This function sends a failure message to a <a href="https://hexdocs.pm/plug/1.3.4/Plug.Conn.html"><code class="inline">Plug.Conn</code></a> connected client</p>
 <h2 id="fail/1-parameters" class="section-heading">
   <a href="#fail/1-parameters" class="hover-link"><i class="icon-link"></i></a>
   Parameters
 </h2>
 
 <ul>
-<li>conn - expects <a href="https://hexdocs.pm/plug/0.14.0/Plug.Conn.html"><code class="inline">Plug.Conn</code></a>
+<li>conn - expects <a href="https://hexdocs.pm/plug/1.3.4/Plug.Conn.html"><code class="inline">Plug.Conn</code></a>
 </li>
 <li>message: <a href="http://elixir-lang.org/docs/stable/elixir/Map.html"><code class="inline">Map</code></a> or <a href="http://elixir-lang.org/docs/stable/elixir/String.html"><code class="inline">String</code></a> error message to report to client
 </li>
@@ -278,7 +278,7 @@ supports skipping one or both extra params</p>
 </h2>
 
 <ul>
-<li>conn - expectes <a href="https://hexdocs.pm/plug/0.14.0/Plug.Conn.html"><code class="inline">Plug.Conn</code></a>
+<li>conn - expectes <a href="https://hexdocs.pm/plug/1.3.4/Plug.Conn.html"><code class="inline">Plug.Conn</code></a>
 </li>
 <li>type - passed in type to render the incoming payload as
 </li>
@@ -315,7 +315,7 @@ supports skipping one or both extra params</p>
 </h2>
 
 <ul>
-<li>conn - expectes <a href="https://hexdocs.pm/plug/0.14.0/Plug.Conn.html"><code class="inline">Plug.Conn</code></a>
+<li>conn - expectes <a href="https://hexdocs.pm/plug/1.3.4/Plug.Conn.html"><code class="inline">Plug.Conn</code></a>
 </li>
 <li>body - response body <a href="http://elixir-lang.org/docs/stable/elixir/Map.html"><code class="inline">Map</code></a> or <a href="http://elixir-lang.org/docs/stable/elixir/String.html"><code class="inline">String</code></a> that is parsed into Json
 </li>

--- a/docs/Router.Base.html
+++ b/docs/Router.Base.html
@@ -107,13 +107,13 @@ each controller’s defined path</p>
     <a href="#call/2">call(conn, opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a></p>
 </div>
   
 </div>
 <div class="summary-row">
   <div class="summary-signature">
-    <a href="#handle_errors/2">handle_errors(conn, map)</a>
+    <a href="#handle_errors/2">handle_errors(conn, assigns)</a>
   </div>
   
     <div class="summary-synopsis"><p>raised errors from http requests are handled here</p>
@@ -125,7 +125,7 @@ each controller’s defined path</p>
     <a href="#init/1">init(opts)</a>
   </div>
   
-    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
+    <div class="summary-synopsis"><p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a></p>
 </div>
   
 </div>
@@ -166,7 +166,7 @@ each controller’s defined path</p>
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:call/2"><code class="inline">Plug.call/2</code></a>.</p>
 
   </section>
 </div>
@@ -176,7 +176,7 @@ each controller’s defined path</p>
     <a href="#handle_errors/2" class="detail-link" title="Link to this function">
       <i class="icon-link"></i>
     </a>
-    <span class="signature">handle_errors(conn, map)</span>
+    <span class="signature">handle_errors(conn, assigns)</span>
     
       <a href="https://github.com/chiengineer/json_svc_ex/blob/master/lib/router/base.ex#L31" class="view-source" rel="help" title="View Source">
        <i class="icon-code"></i>
@@ -194,7 +194,7 @@ each controller’s defined path</p>
   <section class="docstring">
     <p>raised errors from http requests are handled here</p>
 <ul>
-<li><a href="Response.Json.html#fail/2"><code class="inline">Response.Json.fail/2</code></a> sent to <a href="https://hexdocs.pm/plug/0.14.0/Plug.Conn.html"><code class="inline">Plug.Conn</code></a> client
+<li><a href="Response.Json.html#fail/2"><code class="inline">Response.Json.fail/2</code></a> sent to <a href="https://hexdocs.pm/plug/1.3.4/Plug.Conn.html"><code class="inline">Plug.Conn</code></a> client
 </li>
 <li>error reported via <a href="ErrorReporter.Honeybadger.html"><code class="inline">ErrorReporter.Honeybadger</code></a>
 </li>
@@ -218,7 +218,7 @@ each controller’s defined path</p>
     
   </div>
   <section class="docstring">
-    <p>Callback implementation for <a href="https://hexdocs.pm/plug/0.14.0/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
+    <p>Callback implementation for <a href="https://hexdocs.pm/plug/1.3.4/Plug.html#c:init/1"><code class="inline">Plug.init/1</code></a>.</p>
 
   </section>
 </div>

--- a/lib/controller/account.ex
+++ b/lib/controller/account.ex
@@ -19,7 +19,7 @@ defmodule Controller.Account do
   plug :dispatch
 
   post "/" do
-    account_request = Json.parse(conn, type: Request)
+    account_request = Json.parse(conn, type: %Request{})
     Request.validate!(account_request)
     {:ok , request_payload} = Kafka.publish(account_request)
     Json.render(

--- a/test/response/json_test.exs
+++ b/test/response/json_test.exs
@@ -59,4 +59,22 @@ defmodule Response.JsonTest do
     assert(result.status == 500)
   end
 
+  test "renders a json payload to a map" do
+    conn = conn(:post, "/about/foo", "{\"foo\":\"bar\"}")
+             |> put_req_header("content-type", "application/json")
+    result = Json.parse(conn)
+    assert(result == %{"foo" => "bar"})
+  end
+
+  defmodule MockType do
+    defstruct [:foo]
+  end
+
+  test "renders a json payload to a specific map struct" do
+    conn = conn(:post, "/about/foo", "{\"foo\":\"bar\"}")
+             |> put_req_header("content-type", "application/json")
+    result = Json.parse(conn, type: %MockType{})
+    assert(result == %MockType{foo: "bar"})
+  end
+
 end


### PR DESCRIPTION
1. adds test for `Response.Json.parse` testing and uses correct calls for setting the object type.
1. updates docs with new versions