### PR TITLE
Socket use sockets for responses

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,7 @@ config :logger,
 #update this with your relevant host details or use dev.overrides.exs
 
 config :kafka_ex,
-  brokers: [{"192.168.99.100", 32769}],
+  brokers: [{"192.168.99.100", 9092}],
   consumer_group: "kafka_ex",
   disable_default_worker: false,
   sync_timeout: 3000,

--- a/lib/channels/request_create.ex
+++ b/lib/channels/request_create.ex
@@ -1,0 +1,53 @@
+require Logger
+
+defmodule JsonSvc.Channels.RequestCreate do
+  @moduledoc """
+  RequestCreate Channel is used to watch for updates against Account Create
+  Requests. It is a pubsub for a specific request ID from a given user
+  """
+  use Phoenix.Channel
+
+  alias Phoenix.PubSub, as: PubSub
+  alias JsonSvc.Channels.RequestCreate, as: Self
+  alias KafkaHandlers.Account.ResultCreate, as: Listener
+
+  def join(token, _auth_message, socket) do
+    Logger.info "user joining RequestCreate observer"
+    channel = "request_create:" <> token
+    looping_publish_events_to_channelp(token)
+    :ok = PubSub.subscribe(Self, channel)
+    PubSub.broadcast(Self, channel, "Fetching Events")
+
+    {:ok, socket}
+  end
+
+  def leave(_token, _reason, _socket) do
+    :ok
+  end
+
+  def handle_in(_, _, socket, _) do
+    {:noreply, socket}
+  end
+
+  def handle_out("new_msg", payload, socket) do
+    push socket, "new_msg", payload
+    {:noreply, socket}
+  end
+
+  def broadcast_to_channel(message, channel) do
+    PubSub.broadcast(
+      Self,
+      "request_create:" <> channel,
+      message)
+  end
+
+  defp looping_publish_events_to_channelp(transaction_id) do
+    {:ok, pid} = GenServer.start_link(
+      Listener,
+      [], id: :"#{transaction_id}")
+    GenServer.cast(pid, {:fetch_events,
+      %{id: transaction_id, handler: &broadcast_to_channel/2}
+    })
+    :ok
+  end
+end

--- a/lib/channels/room.ex
+++ b/lib/channels/room.ex
@@ -1,0 +1,27 @@
+require Logger
+
+defmodule JsonSvc.Channels.Room do
+  @moduledoc """
+  Room Channel is a general purpose pubsub for events to be used as an example
+  """
+  use Phoenix.Channel
+  alias Phoenix.PubSub, as: PubSub
+  alias JsonSvc.Channels.Room, as: Self
+
+  def join("room:lobby", auth_message, socket) do
+    Logger.info "user joining Lobby"
+    :ok = PubSub.subscribe(Self, "room:lobby")
+    {:ok, socket}
+  end
+
+  def handle_in("new_msg", %{"body" => body}, socket, %{channel: channel}) do
+    PubSub.broadcast(Self, channel, body)
+    {:noreply, socket}
+  end
+
+  def handle_out("new_msg", payload, socket) do
+    push socket, "new_msg", payload
+    {:noreply, socket}
+  end
+
+end

--- a/lib/kafka_handlers/account/accounts.ex
+++ b/lib/kafka_handlers/account/accounts.ex
@@ -50,15 +50,4 @@ defmodule KafkaHandlers.Account.Accounts do
       created_at: Helper.now_string()
     }
   end
-
-  @spec payload_normalizer(map, String.t, String.t) :: map
-  defp payload_normalizer(payload, timestamp, uuid) do
-    %{
-      meta: %{
-        requested_at: timestamp,
-        transaction_id: uuid
-      },
-      request_body: payload
-    }
-  end
 end

--- a/lib/kafka_handlers/account/handle_create.ex
+++ b/lib/kafka_handlers/account/handle_create.ex
@@ -9,6 +9,7 @@ defmodule KafkaHandlers.Account.HandleCreate do
   """
 
   alias KafkaHandlers.Account.Accounts, as: AccountHandler
+  alias Kafka.Helpers, as: Helper
 
   @worker_id :account_handle_request_create_stream
   @topic_model "Account"
@@ -28,17 +29,23 @@ defmodule KafkaHandlers.Account.HandleCreate do
     %{worker_id: @worker_id, partitions: @partitions, topic: @topic}
   end
 
-  def process_batch(message_batch) do
+  def process_batch(message_batch, _options) do
     Logger.info("Processing #{inspect(length(message_batch))} messages")
     message_batch
       |> Flow.from_enumerable()
       |> Flow.map(&Poison.decode!/1)
       |> Flow.map(&AccountHandler.normalize_body/1)
       |> Flow.map(&AccountHandler.create/1)
+      |> Flow.map(&create/1)
       |> Flow.run()
     :created
   end
 
-
-
+  def create({:ok, payload}, handler \\ &KafkaEx.produce/4) do
+    indexed_payload = Helper.index_payload_by_request_id(payload)
+    normalized_payload = Helper.encode_payload_request(indexed_payload)
+    key = Helper.select_random_partition(@partitions)
+    :ok = handler.(@topic, key, normalized_payload, worker_name: @worker_id)
+    {:ok, payload}
+  end
 end

--- a/lib/kafka_handlers/account/result_create.ex
+++ b/lib/kafka_handlers/account/result_create.ex
@@ -1,0 +1,40 @@
+require Logger
+
+defmodule KafkaHandlers.Account.ResultCreate do
+  @moduledoc """
+  Account.ResultCreate is a just in time kafka consumer to watch results from
+  an account request create to be delivered back to any given consumer
+  """
+  use GenServer
+
+  alias Kafka.Helpers, as: Helper
+  alias KafkaHandlers.Account.HandleCreate, as: Consumer
+
+  def handle_cast({:fetch_events, options}, state) do
+    Helper.start_consumers([build_consumer(options)])
+    {:noreply, state}
+  end
+
+  def build_consumer(options) do
+    %{
+      consume: Consumer,
+      handler: &process_batch/2,
+      batch_size: 10,
+      options: options
+    }
+  end
+
+  def process_batch(message_batch, %{id: id, handler: handler}) do
+    Logger.info("Processing #{inspect(length(message_batch))} messages")
+    :ok = message_batch
+      |> Flow.from_enumerable()
+      |> Flow.map(&Poison.decode!/1)
+      |> Flow.filter(fn(message) ->
+          message[id] != nil
+        end)
+      |> Flow.map(&Poison.encode!/1)
+      |> Flow.map(&handler.(&1, id))
+      |> Flow.run()
+    :batch_processed
+  end
+end

--- a/lib/kafka_handlers/consumers.ex
+++ b/lib/kafka_handlers/consumers.ex
@@ -14,9 +14,9 @@ defmodule KafkaHandlers.Consumers do
   @topics [
     %{
       consume: KafkaHandlers.Account.RequestCreate,
-      produce: KafkaHandlers.Account.HandleCreate,
-      handler: &KafkaHandlers.Account.HandleCreate.process_batch/1,
-      batch_size: 10
+      handler: &KafkaHandlers.Account.HandleCreate.process_batch/2,
+      batch_size: 10,
+      options: %{}
     }
   ]
 

--- a/lib/sockets/endpoint.ex
+++ b/lib/sockets/endpoint.ex
@@ -1,0 +1,60 @@
+defmodule JsonSvc.Sockets.Endpoint do
+
+  use Phoenix.Endpoint, otp_app: :json_svc_ex_sockets
+
+    socket :_, JsonSvc.Sockets
+    alias JsonSvc.Channels.Room, as: General
+    alias JsonSvc.Channels.RequestCreate, as: Account
+
+    def init(_, _req, _opts) do
+      {:upgrade, :protocol, :cowboy_websocket}
+    end
+
+    @timeout 60_000 # terminate if no activity for one minute
+
+    #Called on websocket connection initialization.
+    def websocket_init(_type, req, _opts) do
+      state = %{}
+      {:ok, req, state, @timeout}
+    end
+
+    def websocket_handle({:text, "ping"}, req, state) do
+      {:reply, {:text, "pong"}, req, state}
+    end
+
+    def websocket_handle({:text, message}, req, %{channel: "room:" <> name}) do
+      {:noreply, socket} = General.handle_in(
+        "new_msg", %{"body" => message}, req, %{channel: "room:" <> name})
+      {:ok, socket, %{channel: "room:" <> name}}
+    end
+
+    def websocket_handle({:text, "room:" <> name}, req, _state) do
+      {:ok, socket} = General.join("room:" <> name, :req, req)
+      {:ok, socket, %{channel: "room:" <> name}}
+    end
+
+    def websocket_handle({:text, "request_create:" <> token}, req, _state) do
+      {:ok, socket} = Account.join(token, :req, req)
+      {:ok, socket, %{channel: "request_create:" <> token}}
+    end
+
+    # Handle other messages from the browser - don't reply
+    def websocket_handle({:text, _message}, req, state) do
+      {:ok, req, state}
+    end
+
+    # Format and forward elixir messages to client
+    def websocket_info(message, req, state) do
+      {:reply, {:text, message}, req, state}
+    end
+
+    def websocket_terminate(reason, req, %{channel: "request_create:" <> token}) do
+      Account.leave(token, reason, req)
+      :ok
+    end
+
+    # No matter why we terminate, remove all of this pids subscriptions
+    def websocket_terminate(_reason, _req, _state) do
+      :ok
+    end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,9 @@ defmodule JsonSvc.Mixfile do
      { :uuid, "~> 1.1" },
      {:ex_doc, "~> 0.14", only: :dev},
      {:dialyxir, "~> 0.4", only: [:dev, :test], runtime: false},
-     {:flow, "~> 0.11"}
+     {:flow, "~> 0.11"},
+     {:phoenix, "~> 1.2.1"},
+     {:phoenix_pubsub, "~> 1.0"}
    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,8 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "phoenix": {:hex, :phoenix, "1.2.3", "b68dd6a7e6ff3eef38ad59771007d2f3f344988ea6e658e9b2c6ffb2ef494810", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.4 or ~> 1.3.3 or ~> 1.2.4 or ~> 1.1.8 or ~> 1.0.5", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},
   "plug": {:hex, :plug, "1.3.4", "b4ef3a383f991bfa594552ded44934f2a9853407899d47ecc0481777fb1906f6", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},

--- a/test/kafka/helper_test.exs
+++ b/test/kafka/helper_test.exs
@@ -61,7 +61,9 @@ defmodule Kafka.HelpersTest do
         handler: &Kafka.MockHandler.process_batch/1,
         partitions: [0],
         topic: "topic2",
-        worker_id: :worker_id2}
+        worker_id: :worker_id2,
+        options: nil
+      }
     ]
     results = Kafka.Helpers.fetch_worker_ids(mock_topics)
     assert results === expected_result
@@ -84,6 +86,13 @@ defmodule Kafka.HelpersTest do
     {status, pids} = Kafka.Helpers.start_consumers(mock_topics, fetch_messages_handler)
     assert status === :ok
     assert length(pids) == length(mock_topics)
+  end
+
+  test 'index_payload_by_request_id raises errors when request_id is missing' do
+    payload = %{foo: "bar"}
+    assert_raise MatchError, ~r/{:error, :malfomred_request}/, fn ->
+      Kafka.Helpers.index_payload_by_request_id(payload)
+    end
   end
 
 end

--- a/test/kafka/helper_test.exs
+++ b/test/kafka/helper_test.exs
@@ -50,7 +50,7 @@ defmodule Kafka.HelpersTest do
       %{
         consume: MockWorker,
         produce: MockHandler,
-        handler: &MockHandler.process_batch/1,
+        handler: &Kafka.MockHandler.process_batch/1,
         batch_size: 10
       }
     ]
@@ -58,7 +58,7 @@ defmodule Kafka.HelpersTest do
     expected_result = [
       %{
         batch_size: 10,
-        handler: &MockHandler.process_batch/1,
+        handler: &Kafka.MockHandler.process_batch/1,
         partitions: [0],
         topic: "topic2",
         worker_id: :worker_id2}
@@ -72,7 +72,7 @@ defmodule Kafka.HelpersTest do
       %{
         consume: MockWorker,
         produce: MockHandler,
-        handler: &MockHandler.process_batch/1,
+        handler: &Kafka.MockHandler.process_batch/1,
         batch_size: 10
       }
     ]

--- a/test/kafka_handlers/account/handle_create_test.exs
+++ b/test/kafka_handlers/account/handle_create_test.exs
@@ -1,0 +1,48 @@
+defmodule KafkaHandlers.Account.HandleCreateTest do
+  use ExUnit.Case, async: true
+  alias KafkaHandlers.Account.HandleCreate, as: HandleCreate
+
+  test "correct topic is received" do
+    HandleCreate.create(
+      {:ok, Kafka.MockHandler.valid_request_payload},
+      &Kafka.MockHandler.handler/4
+    )
+    assert_received {:payload_sent, [topic, _, _, _]}
+    assert topic == "Account.HandleCreate.V1"
+    refute_received _
+  end
+
+  test "correct partition is received" do
+    HandleCreate.create(
+      {:ok, Kafka.MockHandler.valid_request_payload},
+      &Kafka.MockHandler.handler/4
+    )
+    assert_received {:payload_sent, [_, 0, _, _]}
+    refute_received _
+  end
+
+  test "correct payload is received" do
+    payload = Kafka.MockHandler.valid_request_payload
+    expected_payload = Poison.encode!(%{
+      "#{payload.request_id}": [payload]
+    })
+
+    HandleCreate.create(
+      {:ok, Kafka.MockHandler.valid_request_payload},
+      &Kafka.MockHandler.handler/4
+    )
+    assert_received {:payload_sent, [_, _, payload, _]}
+    assert payload == expected_payload
+    refute_received _
+  end
+
+  test "correct worker name is received" do
+    HandleCreate.create(
+      {:ok, Kafka.MockHandler.valid_request_payload},
+      &Kafka.MockHandler.handler/4
+    )
+    assert_received {:payload_sent, [_, _, _, worker_name: worker_id]}
+    assert worker_id == :account_handle_request_create_stream
+    refute_received _
+  end
+end

--- a/test/kafka_handlers/account/request_create_test.exs
+++ b/test/kafka_handlers/account/request_create_test.exs
@@ -1,22 +1,11 @@
-defmodule MockHandler do
-  def handler(topic, partition, json_payload, worker_name: worker_id) do
-    send self(), {:payload_sent, [topic, partition, json_payload, worker_name: worker_id]}
-    :ok
-  end
-
-  def valid_payload do
-    %{first_name: "joe", last_name: "bob", email: "joe@bob.com"}
-  end
-end
-
 defmodule KafkaHandlers.Account.RequestCreateTest do
   use ExUnit.Case, async: true
   alias KafkaHandlers.Account.RequestCreate, as: RequestCreate
 
   test "correct topic is received" do
     RequestCreate.publish(
-      MockHandler.valid_payload,
-      handler: &MockHandler.handler/4
+      Kafka.MockHandler.valid_payload,
+      handler: &Kafka.MockHandler.handler/4
     )
     assert_received {:payload_sent, [topic, _, _, _]}
     assert topic == "Account.RequestCreate.V1"
@@ -25,8 +14,8 @@ defmodule KafkaHandlers.Account.RequestCreateTest do
 
   test "correct partition is received" do
     RequestCreate.publish(
-      MockHandler.valid_payload,
-      handler: &MockHandler.handler/4
+      Kafka.MockHandler.valid_payload,
+      handler: &Kafka.MockHandler.handler/4
     )
     assert_received {:payload_sent, [_, 0, _, _]}
     refute_received _
@@ -40,14 +29,14 @@ defmodule KafkaHandlers.Account.RequestCreateTest do
         requested_at: DateTime.to_iso8601(timestamp),
         transaction_id: uuid
       },
-      request_body: MockHandler.valid_payload
+      request_body: Kafka.MockHandler.valid_payload
     })
 
     RequestCreate.publish(
-      MockHandler.valid_payload,
+      Kafka.MockHandler.valid_payload,
       timestamp: timestamp,
       request_id: uuid,
-      handler: &MockHandler.handler/4
+      handler: &Kafka.MockHandler.handler/4
     )
     assert_received {:payload_sent, [_, _, payload, _]}
     assert payload == expected_payload
@@ -56,8 +45,8 @@ defmodule KafkaHandlers.Account.RequestCreateTest do
 
   test "correct worker name is received" do
     RequestCreate.publish(
-      MockHandler.valid_payload,
-      handler: &MockHandler.handler/4
+      Kafka.MockHandler.valid_payload,
+      handler: &Kafka.MockHandler.handler/4
     )
     assert_received {:payload_sent, [_, _, _, worker_name: worker_id]}
     assert worker_id == :account_controller_stream
@@ -66,4 +55,8 @@ defmodule KafkaHandlers.Account.RequestCreateTest do
 
   @tag :skip
   test "circle build with live kafka generates workers without stubs"
+
+  test "`create` publishes a payload event indexed by the request_id" do
+
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,21 @@
+defmodule Kafka.MockHandler do
+  def handler(topic, partition, json_payload, worker_name: worker_id) do
+    send self(), {:payload_sent, [topic, partition, json_payload, worker_name: worker_id]}
+    :ok
+  end
+
+  def valid_payload do
+    %{first_name: "joe", last_name: "bob", email: "joe@bob.com"}
+  end
+
+  def valid_request_payload do
+    %{
+      request_id: "33c5aa7e-3f35-47bc-883b-33ea0ace89f0",
+      first_name: "joe", last_name: "bob", email: "joe@bob.com"
+    }
+  end
+end
+
 ExUnit.configure formatters: [JUnitFormatter, ExUnit.CLIFormatter]
 ExUnit.configure(exclude: [skip: true])
 ExUnit.start()


### PR DESCRIPTION
impliments pubsub for socket handling for joining a basic `room:lobby` can be tested via the commandline tool wsc https://github.com/raphael/wsc

connect via websocket:
```
$ wsc ws://localhost:4000/ws
Connected to ws://localhost:4000/ws
> room:lobby # connect to channel
> hello!
< hello!
```

broadcast to a channel via iex (or other process)
```
Phoenix.PubSub.broadcast(JsonSvc.Channels.Room, "room:lobby", "hey friends")
```
in socket appears as:
```
< hey friends
```

still need to write tests.

Phase 2 involves creating room tokens that will fetch/spawn workers to relay status of post requests